### PR TITLE
⚙️ pre-push 세팅

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-echo "🐶 Running git push"
+echo "🐶 Starting git push"
 
 FORBIDDEN_HTTPS_URL="https://github.com/CollaBu/pennyway-client-webview-next.git"
 FORBIDDEN_SSH_URL="git@github.com:CollaBu/pennyway-client-webview-next.git"
@@ -21,4 +21,13 @@ then
     fi
 fi
 
+echo "🐶 Running pnpm build"
+if ! pnpm build
+then
+    echo "🐶 Build failed. Push aborted."
+    exit 1
+fi
+
+
+echo "🐶 Success Pre-Push!"
 exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,24 @@
+echo "🐶 Running git push"
+
+FORBIDDEN_HTTPS_URL="https://github.com/CollaBu/pennyway-client-webview-next.git"
+FORBIDDEN_SSH_URL="git@github.com:CollaBu/pennyway-client-webview-next.git"
+FORBIDDEN_REF="refs/heads/main"
+
+remote="$1"
+url="$2"
+
+if [ "$url" != "$FORBIDDEN_HTTPS_URL" -a "$url" != "$FORBIDDEN_SSH_URL" ]
+then
+    exit 0
+fi
+
+if read local_ref local_sha remote_ref remote_sha
+then
+    if [ "$remote_ref" == "$FORBIDDEN_REF" ]
+    then
+        echo "🐶 Do not push to the main Branch"
+        exit 1
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## 작업 이유

[push](https://github.com/CollaBu/pennyway-client-webview-next/pull/1)

해당 PR 에서 병준님이 말씀주신 대로, 실수로 main 브랜치에서 작업 후 push를 하는 경우를 막기 위해 husky를 활용한 pre-push를 세팅하였습니다.

<br/>

## 작업 사항

### 1️⃣ pre-push 추가
.husky > pre-push 파일을 추가하였습니다. 동작의 경우, 둘 다 메인이라고 가정한다면
 1. pennyway-client-webview-next(저희 원류 레포)의 main 브랜치에서 push 할 시
  => 터미널 내에 "🐶 Do not push to the main Branch" 메시지로 경고와 함께, push가 멈춥니다. (물론, pre-push가 없어도 레포 룰로 인해 main push가 막히나, 리모트에 닿기 전에 push를 막는 것에 의의가 있는 것으로...)
 
 2.원류 레포를 본 따 만든 fork repository일 시
   => 따로 main 브랜치 push의 제한을 두지 않았습니다. fork의 main 브랜치를 push할 경우가 있지 않다고 생각했습니다.

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [ ] pre-push 코드에 특이사항이 있는지
  <br/>

## 발견한 이슈

X
