### PR TITLE
✨ 사용자 검색 모킹 API Handler 추가

### DIFF
--- a/src/app/mocks/data/feed.ts
+++ b/src/app/mocks/data/feed.ts
@@ -1,3 +1,5 @@
+import { IUser, userMockData } from './user';
+
 interface IImage {
   id: number;
   imageUrl: string;
@@ -5,12 +7,7 @@ interface IImage {
 
 interface IFeed {
   id: number;
-
-  user: {
-    id: number;
-    profileImage: string;
-    username: string;
-  };
+  user: IUser;
 
   content: string;
   images: IImage[];
@@ -56,11 +53,7 @@ function generateFeedMockData(count: number) {
   for (let id = 1; id <= count; id++) {
     const feed = {
       id,
-      user: {
-        id: id,
-        profileImage: `https://randomuser.me/api/portraits/${Math.random() > 0.5 ? 'men' : 'women'}/${id}.jpg`,
-        username: `user_${id}`,
-      },
+      user: userMockData[id - 1],
       content: generateRandomContent(Math.floor(Math.random() * 300)),
       images: generateRandomImages(),
       likeCount: Math.floor(Math.random() * 1000),

--- a/src/app/mocks/data/index.ts
+++ b/src/app/mocks/data/index.ts
@@ -1,1 +1,2 @@
 export * from './feed';
+export * from './user';

--- a/src/app/mocks/data/user.ts
+++ b/src/app/mocks/data/user.ts
@@ -1,4 +1,4 @@
-interface IUser {
+export interface IUser {
   id: number;
   profileImage: string;
   username: string;

--- a/src/app/mocks/data/user.ts
+++ b/src/app/mocks/data/user.ts
@@ -1,0 +1,28 @@
+interface IUser {
+  id: number;
+  profileImage: string;
+  username: string;
+}
+
+function generateRandomUsername(id: number) {
+  const prefixes = ['user', 'player', 'guest', 'member', 'star'];
+  return prefixes[Math.floor(Math.random() * prefixes.length)] + id;
+}
+
+function generateUserMockData(count: number) {
+  const mockUsers: IUser[] = [];
+
+  for (let id = 1; id <= count; id++) {
+    const user = {
+      id,
+      profileImage: `https://randomuser.me/api/portraits/${Math.random() > 0.5 ? 'men' : 'women'}/${id - 1}.jpg`,
+      username: generateRandomUsername(id),
+    };
+
+    mockUsers.push(user);
+  }
+
+  return mockUsers;
+}
+
+export const userMockData = generateUserMockData(100);

--- a/src/app/mocks/handlers/search.ts
+++ b/src/app/mocks/handlers/search.ts
@@ -1,10 +1,11 @@
 import Fuse from 'fuse.js';
 import { http } from 'msw';
 
-import { feedMockData } from '../data';
+import { feedMockData, userMockData } from '../data';
 import { createHttpErrorResponse, createHttpSuccessResponse } from '../lib';
 
 export const searchHandlers = [
+  // 1️⃣ 피드 검색
   http.get('http://api.example.com/v2/feeds', ({ request }) => {
     const url = new URL(request.url);
 
@@ -29,6 +30,40 @@ export const searchHandlers = [
 
     return createHttpSuccessResponse({
       feed: {
+        contents,
+        currentPageNumber: page,
+        pageSize: size,
+        numberOfElements: contents.length,
+        hasNextPage,
+      },
+    });
+  }),
+
+  // 2️⃣ 사용자 검색
+  http.get('http://api.example.com/v2/users', ({ request }) => {
+    const url = new URL(request.url);
+
+    const target = url.searchParams.get('target');
+    const page = Number(url.searchParams.get('page') || 1);
+    const size = Number(url.searchParams.get('size') || 15);
+
+    if (!target || target.length < 2) {
+      return createHttpErrorResponse('검색어는 최소 2글자 이상이어야 합니다');
+    }
+
+    const fuse = new Fuse(userMockData, {
+      keys: ['username'],
+    });
+
+    const contents = fuse
+      .search(target)
+      .map((result) => result.item)
+      .slice((page - 1) * size, page * size);
+    const totalFeeds = contents.length;
+    const hasNextPage = totalFeeds > page * size;
+
+    return createHttpSuccessResponse({
+      user: {
         contents,
         currentPageNumber: page,
         pageSize: size,

--- a/src/app/mocks/handlers/search.ts
+++ b/src/app/mocks/handlers/search.ts
@@ -9,11 +9,11 @@ export const searchHandlers = [
   http.get('http://api.example.com/v2/feeds', ({ request }) => {
     const url = new URL(request.url);
 
-    const query = url.searchParams.get('query');
+    const target = url.searchParams.get('target');
     const page = Number(url.searchParams.get('page') || 1);
     const size = Number(url.searchParams.get('size') || 15);
 
-    if (!query || query.length < 2) {
+    if (!target || target.length < 2) {
       return createHttpErrorResponse('검색어는 최소 2글자 이상이어야 합니다');
     }
 
@@ -22,7 +22,7 @@ export const searchHandlers = [
     });
 
     const contents = fuse
-      .search(query)
+      .search(target)
       .map((result) => result.item)
       .slice((page - 1) * size, page * size);
     const totalFeeds = contents.length;


### PR DESCRIPTION
## CheckList

- [ ] `gap`을 이용하여 자식 요소간의 간격을 제어하였나요? (iOS 14 미지원으로 gap -> space between 적용)

## 작업 이유

- 유저 검색 Mock API 구현

## 작업 사항

Feed API와 동일한 방식으로 mock api를 작성하였습니다.

기존에 Feed API 검색어에 대한 쿼리 변수명을 Search API Spec에 나온대로 수정(`query` -> `target`)하였습니다.

- 의찬님이 저번에 알려주신 es-hangul 라이브러리를 적용하려고 문서를 찾아보았는데, 현재 모킹 데이터가 한글 기반이 아닌 영어로만 이루어져있다보니 es-hangul의 장점을 극대화하기 어렵다고 판단하여 기존에 사용하고 있었던 fuse 라이브러리를 적용하였습니다.

- Feed 모킹 데이터에 포함된 User 정보가 User 모킹 데이터의 인터페이스가 동일하여 Feed 모킹 데이터의 User가 User 모킹 데이터를 가르키도록 수정하였습니다.

## 리뷰어가 중점적으로 확인해야 하는 부분

- 사용자 검색 모킹 API에 대한 테스트는 아래 코드로 확인하실 수 있습니다!

```tsx
'use client';

import { useEffect, useState } from 'react';

export function SearchBar() {
  const [target, setTarget] = useState('');

  useEffect(() => {
    (async () => {
      if (target.length < 2) return;

      const response = await fetch(`http://api.example.com/v2/users?target=${target}`);
      const result = await response.json();
      console.info(result);
    })();
  }, [target]);

  return <input value={target} onChange={(e) => setTarget(e.target.value)} />;
}
```

## 발견한 이슈

- 수환님 PR 병합하시면 병합된 커밋에 대해 cherry-pick 이용해서 가져와서 병합하겠습니당