### PR TITLE
✨ 피드 작성, 수정 모킹 API Handler 추가

### DIFF
--- a/src/app/mocks/handlers/feed.ts
+++ b/src/app/mocks/handlers/feed.ts
@@ -1,29 +1,16 @@
 import { http } from 'msw';
 
-import { feedMockData } from '../data';
+import { IReportFeedReqDTO, IWriteFeedReqDTO } from '@/entities/feed';
+
 import { feedMockData } from '../data';
 import { createHttpErrorResponse, createHttpSuccessResponse } from '../lib';
-
-interface IReportFeedReqDTO {
-  category: string;
-  content: string;
-  isBlind: boolean;
-}
-
-interface IWriteFeedReqDTO {
-  content: string;
-  images: string[];
-  scope: TFeedScope;
-}
-
-type TFeedScope = 'public' | 'friends' | 'private';
 
 export const feedHandlers = [
   // 1️⃣ 피드 신고
   http.post('http://api.example.com/v2/feeds/:feedId/reports', async ({ request, params }) => {
     const { feedId } = params;
 
-    const { category, content } = (await request.json()) as IReportFeedReqDTO;
+    const { category, isBlind } = (await request.json()) as IReportFeedReqDTO;
 
     if (!feedId || !category) {
       return createHttpErrorResponse('피드 ID, 신고 카테고리가 필수로 입력되어야 합니다.');

--- a/src/app/mocks/handlers/feed.ts
+++ b/src/app/mocks/handlers/feed.ts
@@ -1,17 +1,29 @@
 import { http } from 'msw';
 
 import { feedMockData } from '../data';
+import { feedMockData } from '../data';
 import { createHttpErrorResponse, createHttpSuccessResponse } from '../lib';
-interface IReportFeedReqDto {
+
+interface IReportFeedReqDTO {
   category: string;
   content: string;
   isBlind: boolean;
 }
+
+interface IWriteFeedReqDTO {
+  content: string;
+  images: string[];
+  scope: TFeedScope;
+}
+
+type TFeedScope = 'public' | 'friends' | 'private';
+
 export const feedHandlers = [
+  // 1️⃣ 피드 신고
   http.post('http://api.example.com/v2/feeds/:feedId/reports', async ({ request, params }) => {
     const { feedId } = params;
 
-    const { category, isBlind } = (await request.json()) as IReportFeedReqDto;
+    const { category, content } = (await request.json()) as IReportFeedReqDTO;
 
     if (!feedId || !category) {
       return createHttpErrorResponse('피드 ID, 신고 카테고리가 필수로 입력되어야 합니다.');
@@ -28,5 +40,59 @@ export const feedHandlers = [
     return createHttpSuccessResponse({
       isReported: true,
     });
+  }),
+
+  // 2️⃣ 피드 작성
+  http.post('http://api.example.com/v2/feeds', async ({ request }) => {
+    const { content, images, scope } = (await request.json()) as IWriteFeedReqDTO;
+
+    if (!content) {
+      return createHttpErrorResponse('피드 등록을 위해 컨텐츠를 작성해야 합니다.');
+    } else if (!scope) {
+      return createHttpErrorResponse('피드 등록을 위해 공개 범위를 설정해야 합니다.');
+    }
+
+    feedMockData.push({
+      id: feedMockData.length + 1,
+      user: { ...feedMockData[feedMockData.length - 1].user },
+      content,
+      images: images.map((url, index) => ({ id: index + 1, imageUrl: url })),
+      likeCount: 0,
+      commentCount: 0,
+      isLiked: false,
+      isBookmarked: false,
+      isBlinded: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    return createHttpSuccessResponse({});
+  }),
+
+  // 3️⃣ 피드 수정
+  http.put('http://api.example.com/v2/feeds/:feedId', async ({ request, params }) => {
+    const { feedId } = params;
+
+    const { content, images, scope } = (await request.json()) as IWriteFeedReqDTO;
+
+    if (!content) {
+      return createHttpErrorResponse('피드 수정을 위해 컨텐츠를 작성해야 합니다.');
+    } else if (!scope) {
+      return createHttpErrorResponse('피드 수정을 위해 공개 범위를 설정해야 합니다.');
+    }
+
+    feedMockData.forEach((feed) => {
+      const numFeedId = +feedId;
+      if (feed.id === numFeedId) {
+        feedMockData[numFeedId] = {
+          ...feedMockData[numFeedId],
+          content,
+          images: images.map((url, index) => ({ id: index + 1, imageUrl: url })),
+          updatedAt: new Date().toISOString(),
+        };
+      }
+    });
+
+    return createHttpSuccessResponse({});
   }),
 ];

--- a/src/entities/feed/model/common.type.ts
+++ b/src/entities/feed/model/common.type.ts
@@ -19,16 +19,4 @@ export interface IFeed {
   updatedAt: string;
 }
 
-export interface IReportFeedReqDTO {
-  category: string;
-  content: string;
-  isBlind: boolean;
-}
-
-export interface IWriteFeedReqDTO {
-  content: string;
-  images: string[];
-  scope: TFeedScope;
-}
-
 export type TFeedScope = 'public' | 'friends' | 'private';

--- a/src/entities/feed/model/index.ts
+++ b/src/entities/feed/model/index.ts
@@ -1,1 +1,3 @@
-export * from './types';
+export * from './common.type';
+export * from './report.type';
+export * from './write.type';

--- a/src/entities/feed/model/index.ts
+++ b/src/entities/feed/model/index.ts
@@ -1,1 +1,1 @@
-export * from './type';
+export * from './types';

--- a/src/entities/feed/model/report.type.ts
+++ b/src/entities/feed/model/report.type.ts
@@ -1,0 +1,5 @@
+export interface IReportFeedReqDTO {
+  category: string;
+  content: string;
+  isBlind: boolean;
+}

--- a/src/entities/feed/model/types.ts
+++ b/src/entities/feed/model/types.ts
@@ -18,3 +18,17 @@ export interface IFeed {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface IReportFeedReqDTO {
+  category: string;
+  content: string;
+  isBlind: boolean;
+}
+
+export interface IWriteFeedReqDTO {
+  content: string;
+  images: string[];
+  scope: TFeedScope;
+}
+
+export type TFeedScope = 'public' | 'friends' | 'private';

--- a/src/entities/feed/model/write.type.ts
+++ b/src/entities/feed/model/write.type.ts
@@ -1,0 +1,7 @@
+import { TFeedScope } from './common.type';
+
+export interface IWriteFeedReqDTO {
+  content: string;
+  images: string[];
+  scope: TFeedScope;
+}


### PR DESCRIPTION
## CheckList

- [ ] `gap`를 이용하여 flex 컨테이너 내 자식 요소간의 간격을 제어하였나요? (iOS 14 미지원으로 gap -> space-x, space-y 적용)

## 작업 이유
- 피드 작성, 수정 모킹 API Handler 개발 진행
- 피드 API Handler에 있는 신고, 작성and수정 request dto의 위치를entities으로 조정
<br/>

## 작업 사항

### 1️⃣ 피드 작성, 수정 mock api 구현

피드 작성, 수정 mock api를 구현해두었습니다!

### 2️⃣ 피드 mock api Request DTO 위치 조정

기존 mocks/handlers/feed.ts에 존재하는 신고하기의 request dto와 이번에 제작된 작성&수정의 request dto를 entities/feed/model/types.ts 로 이동시켰습니다.

이후, 실제 API request 코드 작성 시에도 사용될 타입이기 때문에 해당근거로 다음과 같은 위치로 이동을 시켜두었던 것 같습니다!

<br/>

## 리뷰어가 중점적으로 확인해야 하는 부분

- [x] 피드 작성, 수정 mock api의 로직에 특이사항이 있는지
- [x] 피드 Request DTO의 위치가 합당한지
  <br/>

## 발견한 이슈

X
